### PR TITLE
Add invoice file download support

### DIFF
--- a/src/main/java/de/focus_shift/lexoffice/java/sdk/chain/InvoiceChain.java
+++ b/src/main/java/de/focus_shift/lexoffice/java/sdk/chain/InvoiceChain.java
@@ -1,11 +1,16 @@
 package de.focus_shift.lexoffice.java.sdk.chain;
 
 import de.focus_shift.lexoffice.java.sdk.RequestContext;
+import com.google.common.base.Preconditions;
+import de.focus_shift.lexoffice.java.sdk.model.DocumentFile;
 import de.focus_shift.lexoffice.java.sdk.model.Invoice;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class InvoiceChain {
@@ -18,6 +23,10 @@ public class InvoiceChain {
 
     public Create create() {
         return new Create(context);
+    }
+
+    public FileDownload file(String id) {
+        return new FileDownload(context, id);
     }
 
     protected static class Get extends ExecutableRequestChain {
@@ -52,6 +61,42 @@ public class InvoiceChain {
         @SneakyThrows
         public Invoice submit(Invoice invoice) {
             return getContext().execute(getUriBuilder(), HttpMethod.POST, invoice, TYPE_REFERENCE);
+        }
+    }
+
+    public static class FileDownload extends ExecutableRequestChain {
+        private static final Set<MediaType> SUPPORTED_MEDIA_TYPES = Set.of(MediaType.APPLICATION_PDF, MediaType.APPLICATION_XML, MediaType.ALL);
+        private final String invoiceId;
+        private MediaType accept = MediaType.APPLICATION_PDF;
+
+        public FileDownload(RequestContext context, String invoiceId) {
+            super(context, "/invoices");
+            this.invoiceId = Preconditions.checkNotNull(invoiceId, "invoiceId must not be null");
+            getUriBuilder().appendPath("/" + this.invoiceId + "/file");
+        }
+
+        public FileDownload asPdf() {
+            return accept(MediaType.APPLICATION_PDF);
+        }
+
+        public FileDownload asXml() {
+            return accept(MediaType.APPLICATION_XML);
+        }
+
+        public FileDownload anyRepresentation() {
+            return accept(MediaType.ALL);
+        }
+
+        public FileDownload accept(MediaType mediaType) {
+            Preconditions.checkNotNull(mediaType, "mediaType must not be null");
+            Preconditions.checkArgument(SUPPORTED_MEDIA_TYPES.contains(mediaType), "Unsupported media type %s", mediaType);
+            this.accept = mediaType;
+            return this;
+        }
+
+        @SneakyThrows
+        public DocumentFile download() {
+            return getContext().execute(getUriBuilder(), HttpMethod.GET, accept);
         }
     }
 

--- a/src/main/java/de/focus_shift/lexoffice/java/sdk/model/DocumentFile.java
+++ b/src/main/java/de/focus_shift/lexoffice/java/sdk/model/DocumentFile.java
@@ -1,0 +1,19 @@
+package de.focus_shift.lexoffice.java.sdk.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.MediaType;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DocumentFile {
+
+    private byte[] content;
+    private MediaType contentType;
+    private Long contentLength;
+    private String filename;
+}


### PR DESCRIPTION
## Summary
- extend the request context with binary download capabilities and reuse throttling
- add an invoice file download chain with media type selection helpers
- introduce a DocumentFile model and cover the new flow with unit tests

## Testing
- mvn -q test *(fails: JAVA_HOME environment variable not defined in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4109e017883299fbf877926f14a56